### PR TITLE
improve compatibility with older versions of bash

### DIFF
--- a/git-auto
+++ b/git-auto
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## Tested on macOS big sur 11.2.1
 ## Usage:
@@ -46,7 +46,7 @@ if [[ -z "${branch}" ]]; then
   branch=$(git rev-parse --abbrev-ref HEAD)
 fi
 
-function auto-commit-and-push() {
+auto-commit-and-push() {
   if ! [[ $(git status) =~ "working tree clean" ]]; then
     git add .
     git commit -m "auto commit"


### PR DESCRIPTION
```diff
+ instead of defaulting to older bash binaries allow the shebang to search for the most recent binary of bash in the env 
```

[Details <--](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my)

```diff
- remove the `function` keyword for bash function. Makes the script more portable and POSIX compliant 
```

[Details <--](https://stackoverflow.com/questions/7917018/what-is-the-function-keyword-used-in-some-bash-scripts)
